### PR TITLE
Add *.xcconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ fastlane/test_output
 
 iOSInjectionProject/
 .DS_Store
+*.xcconfig


### PR DESCRIPTION
Adding *.xcconfig to .gitignore file to ignore the configuration settings files if you use it to hide keys and data, as you don't want to add it to source control